### PR TITLE
Moves some specs from RLPSpec to PreludeSpec

### DIFF
--- a/test/Ethereum/PreludeSpec.hs
+++ b/test/Ethereum/PreludeSpec.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Ethereum.PreludeSpec(spec) where
+
+import Ethereum.Testing
+import Test.Hspec
+import Test.QuickCheck
+import Ethereum.Prelude
+import qualified Data.ByteString as BS
+
+spec :: Spec
+spec = do
+  describe "decodeInt" $ do
+    it "should decode what it encodes (ints)" $ property $ \n ->
+      (n :: Int) >= 0 ==> (decodeInt . encodeInt $ n) `shouldBe` Just n
+
+    it "fails to decode zero-prefixed integers" $ property $ \n padding ->
+      padding > 0  && n >= 0 ==>
+        let padded = BS.replicate padding 0 <> encodeInt (n :: Int)
+        in decodeInt padded `shouldBe` Nothing
+
+  describe "encodeInt" $ do
+    it "should encode 15" $ encodeInt 15 `shouldBe` "\x0f"
+    it "should encode 1024" $ encodeInt 1024 `shouldBe` "\x04\x00"

--- a/test/Ethereum/RLPSpec.hs
+++ b/test/Ethereum/RLPSpec.hs
@@ -81,19 +81,6 @@ instance RLP.Convertible Breaky
 
 spec :: Spec
 spec = do
-
-  it "should decode what it encodes (ints)" $ property $ \n ->
-    (n :: Int) >= 0 ==> (decodeInt . encodeInt $ n) `shouldBe` Just n
-
-  it "fails to decode zero-prefixed integers" $ property $ \n padding ->
-    padding > 0  && n >= 0 ==>
-      let padded = BS.replicate padding 0 <> encodeInt (n :: Int)
-      in decodeInt padded `shouldBe` Nothing
-
-  describe "handle example integer conversions" $ do
-    it "should encode 15" $ encodeInt 15 `shouldBe` "\x0f"
-    it "should encode 1024" $ encodeInt 1024 `shouldBe` "\x04\x00"
-
   it "should decode what it encodes" $ property $ \rlp ->
     (RLP.decode . RLP.encode $ rlp) `shouldBe` Just rlp
 


### PR DESCRIPTION
It might me interesting to have a separate spec for the Prelude module. I also took the liberty to change a bit the style and use the convention:

```
describe functionName $ do
  it "shoul implement desired behaviour" ...
```

(I know this PR does not do much, but I just wanted to know your thoughts on specs conventions before implementing new things)
